### PR TITLE
Omit metadata and fix column headers for large datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ console.log(dataset.data)
 ```
 
 
-### Specifiy a column to return
+### Specifiy a column
 
 ```javascript
 const { createClient } = require('cmsdata-client');
@@ -93,7 +93,7 @@ const dataset = await CMSClient.limit().select("nppes_provider_first_name").get(
 console.log(dataset.data)
 ```
 
-### Specifiy multiple columns to return
+### Specifiy multiple columns
 
 ```javascript
 const { createClient } = require('cmsdata-client');

--- a/index.js
+++ b/index.js
@@ -130,6 +130,8 @@ class CMSClient {
 
       await this._fetchResourceMetadata();
 
+      if (!this.fetchOptions.includeMetadata) delete this.fetched.metadata;
+
       switch (this.type) {
         case 'csv':
           this.fetched.data = await resourceData.text();
@@ -147,8 +149,7 @@ class CMSClient {
     try {
       const metadataUrl = `https://data.cms.gov/api/views/metadata/v1/${this.resourceId}`;
       const metadata = await fetch(metadataUrl);
-      if (this.fetchOptions.includeMetada)
-        this.fetched.metadata = await metadata.json();
+      this.fetched.metadata = await metadata.json();
     } catch (error) {
       throw new Error(error);
     }
@@ -169,7 +170,6 @@ class CMSClient {
       console.warn('Data is outdated');
     }
 
-    if (!this.fetchOptions.includeMetada) delete this.fetched.metadata;
     return this.fetched;
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -1,15 +1,23 @@
 const { test } = require('tap');
 const { createClient } = require('./index');
 
-test('Query all records', async (t) => {
+test('Query all records with metadata', async (t) => {
   const CMSClient = createClient('5fr6-cch3', {
     output: 'json',
     includeMetadata: true,
   });
 
   const dataset = await CMSClient.select().get();
+  t.ok(dataset.data, 'Returns all records with metadata');
+});
 
-  t.ok(dataset.data, 'Returns all records');
+test('Query all records without metadata', async (t) => {
+  const CMSClient = createClient('5fr6-cch3', {
+    output: 'json',
+  });
+
+  const dataset = await CMSClient.select().get();
+  t.ok(dataset.data, 'Returns all records without metadata');
 });
 
 test('Query all records with a selected column', async (t) => {
@@ -19,7 +27,6 @@ test('Query all records with a selected column', async (t) => {
   });
 
   const dataset = await CMSClient.select('nppes_provider_first_name').get();
-
   t.ok(dataset.data, 'Returns all records with a selected column');
 });
 


### PR DESCRIPTION
- The the first commit should have been with the previous PR but it was merged before I was able to do another commit. Cleaned up testing to be more consistent. 

- Second commit fixes #2, for large datasets that do not return`X-SODA2-Fields` we just peek at keys of the the first object. Assuming all objects have the same keys. 

