### PR TITLE
Support streaming response body to stream destination and remove dependencies

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ docs
 coverage
 node_modules
 .vscode
+build/index.js

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,7 @@ name: Node.js Package
 
 on:
   release:
-    types: [created]
+    push: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 docs
 .nyc_output
 coverage
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
-  },
-  "eslint.validate": ["javascript"]
- }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 const fetch = require('node-fetch');
-const crossFetch = require('cross-fetch');
-const isNode = require('detect-node');
-
 class CMSClient {
   /**
    * Create a client
@@ -130,14 +127,10 @@ class CMSClient {
   async _fetchResource() {
     let resourceData;
     try {
-      if (isNode) {
-        resourceData = await fetch(this.url);
+      resourceData = await fetch(this.url);
 
-        if (this.fetchOptions.stream && this._isSafeToStream()) {
-          await resourceData.body.pipe(this.fetchOptions.stream);
-        }
-      } else {
-        resourceData = await crossFetch(this.url);
+      if (this.fetchOptions.stream && this._isSafeToStream()) {
+        await resourceData.body.pipe(this.fetchOptions.stream);
       }
 
       const headers = await resourceData.headers;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const fetch = require('cross-fetch');
+const fetch = require('node-fetch');
 
 class CMSClient {
   /**
@@ -10,7 +10,8 @@ class CMSClient {
     this.resourceId = resourceId;
     this.isOutdated = false;
     this.lastModified = '';
-    this.type = options.output || 'json';
+    this.type =
+      options && typeof options.output === 'string' ? options.output : 'json';
     this.url = `https://data.cms.gov/resource/${this.resourceId}.${this.type}`;
     this.fetchOptions = {
       ...options,

--- a/index.test.js
+++ b/index.test.js
@@ -1,18 +1,13 @@
 const { test } = require('tap');
 const { createClient } = require('./index');
+const fs = require('fs');
+const path = require('path');
 
 test('Query all records with metadata', async (t) => {
   const CMSClient = createClient('5fr6-cch3', {
     output: 'json',
     includeMetadata: true,
   });
-
-  const dataset = await CMSClient.select().get();
-  t.ok(dataset.data, 'Returns all records with metadata');
-});
-
-test('Query all records without options', async (t) => {
-  const CMSClient = createClient('5fr6-cch3');
 
   const dataset = await CMSClient.select().get();
   t.ok(dataset.data, 'Returns all records with metadata');
@@ -25,6 +20,22 @@ test('Query all records without metadata', async (t) => {
 
   const dataset = await CMSClient.select().get();
   t.ok(dataset.data, 'Returns all records without metadata');
+});
+
+test('Query all records without options', async (t) => {
+  const CMSClient = createClient('5fr6-cch3');
+
+  const dataset = await CMSClient.select().get();
+  t.ok(dataset.data, 'Returns all records with metadata');
+});
+
+test('Query all records with csv output', async (t) => {
+  const CMSClient = createClient('5fr6-cch3', {
+    output: 'csv',
+  });
+
+  const dataset = await CMSClient.select().get();
+  t.ok(dataset.data, 'Returns all records in csv format');
 });
 
 test('Query all records with a selected column', async (t) => {
@@ -56,7 +67,7 @@ test('Query by a column with limit', async (t) => {
   t.ok(dataset.data, 'Returns limited records with a selected column');
 });
 
-test('Query by multiple column', async (t) => {
+test('Query by multiple columns', async (t) => {
   const CMSClient = createClient('5fr6-cch3', {
     output: 'json',
     includeMetadata: true,
@@ -81,13 +92,33 @@ test('Query by multiple columns with limit', async (t) => {
   t.ok(dataset.data, 'Returns limited records with multiple selected records');
 });
 
-test('Order by a column', async (t) => {
+test('Query all records ordered by selected column', async (t) => {
   const CMSClient = createClient('5fr6-cch3', {
     output: 'json',
     includeMetadata: true,
   });
 
   const dataset = await CMSClient.order('nppes_provider_state').get();
-  t.ok(dataset.data, 'Returns all records ordered by a column');
+  t.ok(dataset.data, 'Returns all records ordered by selected column');
+  t.end();
+});
+
+test('Stream response body to stream destination', async (t) => {
+  const CMSClient = createClient('5fr6-cch3', {
+    output: 'json',
+    includeMetadata: true,
+    stream: fs.createWriteStream('./streamed.json'),
+  });
+
+  const dataset = await CMSClient.get();
+
+  t.teardown(() => {
+    fs.unlink(path.join(process.cwd(), 'streamed.json'), (error) => {
+      if (error) {
+        throw new Error(error);
+      }
+    });
+  });
+  t.ok(dataset.data, 'Streams response body to file destinaton');
   t.end();
 });

--- a/index.test.js
+++ b/index.test.js
@@ -111,6 +111,7 @@ test('Stream response body to stream destination', async (t) => {
   });
 
   const dataset = await CMSClient.get();
+  t.ok(dataset.data, 'Streams response body to file destinaton');
 
   t.teardown(() => {
     fs.unlink(path.join(process.cwd(), 'streamed.json'), (error) => {
@@ -119,6 +120,6 @@ test('Stream response body to stream destination', async (t) => {
       }
     });
   });
-  t.ok(dataset.data, 'Streams response body to file destinaton');
+
   t.end();
 });

--- a/index.test.js
+++ b/index.test.js
@@ -11,6 +11,13 @@ test('Query all records with metadata', async (t) => {
   t.ok(dataset.data, 'Returns all records with metadata');
 });
 
+test('Query all records without options', async (t) => {
+  const CMSClient = createClient('5fr6-cch3');
+
+  const dataset = await CMSClient.select().get();
+  t.ok(dataset.data, 'Returns all records with metadata');
+});
+
 test('Query all records without metadata', async (t) => {
   const CMSClient = createClient('5fr6-cch3', {
     output: 'json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cmsdata-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -674,14 +674,6 @@
         "request": "^2.88.2"
       }
     },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "requires": {
-        "node-fetch": "2.6.1"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -737,11 +729,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff": {
       "version": "4.0.2",
@@ -800,11 +787,6 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
-    },
-    "esbuild": {
-      "version": "0.12.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
-      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -524,12 +524,12 @@
       "dev": true
     },
     "catharsis": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
-      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "^4.17.15"
       }
     },
     "chalk": {
@@ -672,14 +672,6 @@
         "log-driver": "^1.2.7",
         "minimist": "^1.2.5",
         "request": "^2.88.2"
-      }
-    },
-    "cross-fetch": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
-      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
-      "requires": {
-        "node-fetch": "2.6.1"
       }
     },
     "cross-spawn": {
@@ -1607,25 +1599,25 @@
       "dev": true
     },
     "jsdoc": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
-      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.7.tgz",
+      "integrity": "sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.9.4",
         "bluebird": "^3.7.2",
-        "catharsis": "^0.8.11",
+        "catharsis": "^0.9.0",
         "escape-string-regexp": "^2.0.0",
         "js2xmlparser": "^4.0.1",
         "klaw": "^3.0.0",
         "markdown-it": "^10.0.0",
         "markdown-it-anchor": "^5.2.7",
-        "marked": "^0.8.2",
+        "marked": "^2.0.3",
         "mkdirp": "^1.0.4",
         "requizzle": "^0.2.3",
         "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.10.2"
+        "underscore": "~1.13.1"
       }
     },
     "jsesc": {
@@ -1821,9 +1813,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.7.tgz",
+      "integrity": "sha512-BJXxkuIfJchcXOJWTT2DOL+yFWifFv2yGYOUzvXg8Qz610QKw+sHCvTMYwA+qWGhlA2uivBezChZ/pBy1tWdkQ==",
       "dev": true
     },
     "mdurl": {
@@ -4010,9 +4002,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
-      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+      "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
       "dev": true
     },
     "unicode-length": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -674,6 +674,14 @@
         "request": "^2.88.2"
       }
     },
+    "cross-fetch": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+      "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -729,6 +737,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="
     },
     "diff": {
       "version": "4.0.2",
@@ -787,6 +800,11 @@
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "esbuild": {
+      "version": "0.12.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.8.tgz",
+      "integrity": "sha512-sx/LwlP/SWTGsd9G4RlOPrXnIihAJ2xwBUmzoqe2nWwbXORMQWtAGNJNYLBJJqa3e9PWvVzxdrtyFZJcr7D87g=="
     },
     "escalade": {
       "version": "3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cmsdata-client",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -282,75 +282,6 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@rollup/plugin-commonjs": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-18.1.0.tgz",
-      "integrity": "sha512-h3e6T9rUxVMAQswpDIobfUHn/doMzM9sgkMrsMWCFLmB84PSoC8mV8tOloAJjSRwdqhXBqstlX2BwBpHJvbhxg==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "commondir": "^1.0.1",
-        "estree-walker": "^2.0.1",
-        "glob": "^7.1.6",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7",
-        "resolve": "^1.17.0"
-      }
-    },
-    "@rollup/plugin-node-resolve": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.2.1.tgz",
-      "integrity": "sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^3.1.0",
-        "@types/resolve": "1.17.1",
-        "builtin-modules": "^3.1.0",
-        "deepmerge": "^4.2.2",
-        "is-module": "^1.0.0",
-        "resolve": "^1.19.0"
-      }
-    },
-    "@rollup/pluginutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
-      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "0.0.39",
-        "estree-walker": "^1.0.1",
-        "picomatch": "^2.2.2"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
-          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
-          "dev": true
-        }
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.39",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==",
-      "dev": true
-    },
-    "@types/resolve": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
-      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -554,12 +485,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
-    },
-    "builtin-modules": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
-      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
       "dev": true
     },
     "caching-transform": {
@@ -796,12 +721,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "default-require-extensions": {
@@ -1146,12 +1065,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
-    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1313,12 +1226,6 @@
       "dev": true,
       "optional": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "function-loop": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-2.0.1.tgz",
@@ -1407,15 +1314,6 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
       }
     },
     "has-flag": {
@@ -1512,15 +1410,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-core-module": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-      "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1542,26 +1431,11 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
-      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
-      "dev": true
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
-    },
-    "is-reference": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
-      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*"
-      }
     },
     "is-stream": {
       "version": "2.0.0",
@@ -1918,15 +1792,6 @@
         "yallist": "^4.0.0"
       }
     },
-    "magic-string": {
-      "version": "0.25.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
-      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
-      "dev": true,
-      "requires": {
-        "sourcemap-codec": "^1.4.4"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -2219,12 +2084,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -2407,16 +2266,6 @@
         "lodash": "^4.17.14"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      }
-    },
     "resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
@@ -2430,15 +2279,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      }
-    },
-    "rollup": {
-      "version": "2.47.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.47.0.tgz",
-      "integrity": "sha512-rqBjgq9hQfW0vRmz+0S062ORRNJXvwRpzxhFXORvar/maZqY6za3rgQ/p1Glg+j1hnc1GtYyQCPiAei95uTElg==",
-      "dev": true,
-      "requires": {
-        "fsevents": "~2.3.1"
       }
     },
     "safe-buffer": {
@@ -2552,12 +2392,6 @@
           "dev": true
         }
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "spawn-wrap": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cmsdata-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A JavaScript client for CMS Data",
   "repository": {
     "type": "git",
@@ -12,8 +12,7 @@
     "test": "tap --no-coverage --reporter=specy -J",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --ext .js --fix",
-    "test:report": "tap --coverage-report=html index.test.js",
-    "build:browser": "esbuild index.js --outdir=build --bundle --sourcemap --minify --target=chrome58,firefox57,safari11,edge16"
+    "test:report": "tap --coverage-report=html index.test.js"
   },
   "keywords": [
     "cms",
@@ -23,9 +22,6 @@
   "author": "Consensus Networks",
   "license": "MIT",
   "dependencies": {
-    "cross-fetch": "^3.1.4",
-    "detect-node": "^2.1.0",
-    "esbuild": "^0.12.8",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "tap --no-coverage --reporter=specy -J",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --ext .js --fix",
-    "test:report": "tap --coverage-report=html index.test.js"
+    "test:report": "tap --coverage-report=html index.test.js",
+    "build:browser": "esbuild index.js --outdir=build --bundle --sourcemap --minify --target=chrome58,firefox57,safari11,edge16"
   },
   "keywords": [
     "cms",
@@ -22,6 +23,9 @@
   "author": "Consensus Networks",
   "license": "MIT",
   "dependencies": {
+    "cross-fetch": "^3.1.4",
+    "detect-node": "^2.1.0",
+    "esbuild": "^0.12.8",
     "node-fetch": "^2.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "tap --no-coverage --reporter=specy -J",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --ext .js --fix",
-    "test:report": "tap --coverage-report=html index.test.js",
+    "test:report": "tap --coverage-report=html index.test.js"
   },
   "keywords": [
     "cms",
@@ -22,13 +22,13 @@
   "author": "Consensus Networks",
   "license": "MIT",
   "dependencies": {
-    "cross-fetch": "^3.1.4"
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
-    "jsdoc": "^3.6.6",
+    "jsdoc": "^3.6.7",
     "prettier": "^2.2.1",
     "tap": "^15.0.6"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "tap --no-coverage --reporter=specy -J",
     "lint": "eslint . --ext .js",
     "lint:fix": "eslint . --ext .js --fix",
-    "test:report": "tap --coverage-report=html index.test.js"
+    "test:report": "tap --coverage-report=html index.test.js",
   },
   "keywords": [
     "cms",
@@ -25,14 +25,11 @@
     "cross-fetch": "^3.1.4"
   },
   "devDependencies": {
-    "@rollup/plugin-commonjs": "^18.0.0",
-    "@rollup/plugin-node-resolve": "^11.2.1",
     "eslint": "^7.26.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.4.0",
     "jsdoc": "^3.6.6",
     "prettier": "^2.2.1",
-    "rollup": "^2.46.0",
     "tap": "^15.0.6"
   }
 }


### PR DESCRIPTION
I decided to replace `cross-fetch` with `node-fetch` and to only support node environments for now. I think we should worry being isomorphic in the future. Maybe as a  __good first issue__?

Summary of commits: 
1. Remove unused dependencies
2. Fix #5 
3. Add support to stream response body by piping body -> stream destination
4. Merge into master